### PR TITLE
Fix type warning and enhance dashboard

### DIFF
--- a/app_sorteig.py
+++ b/app_sorteig.py
@@ -6,6 +6,12 @@ from collections import OrderedDict
 from streamlit_option_menu import option_menu  # pip install streamlit-option-menu
 import plotly.express as px
 
+st.set_page_config(
+    page_title="App Sorteig Pla de Caça",
+    layout="wide",
+    menu_items={"Get Help": None, "Report a bug": None, "About": None},
+)
+
 # ── CONSTANTS ────────────────────────────────────────────────────────────────
 
 ESPECIE_SORTEIGS = OrderedDict({
@@ -123,7 +129,9 @@ def sorteig_individual(df, tipus_quant, ordre_aleatori, vedat, rng):
     if "Parroquia" in df.columns:
         df["Parroquia"] = df["Parroquia"].apply(normalitza_parroquia)
 
-    df["assigned"], df["ordre"], df["tipus"] = False, np.nan, np.nan
+    df["assigned"] = False
+    df["ordre"] = pd.Series([pd.NA] * len(df), dtype="Int64")
+    df["tipus"] = pd.Series([pd.NA] * len(df), dtype="object")
     assignats_parr = {k: 0 for k in VEDAT_PARRÒQUIES.get(vedat, {})}
 
     captures_pool = [t for t, q in tipus_quant for _ in range(q)]
@@ -200,11 +208,15 @@ def processar_sorteigs(df1, df2, config, especie, seed):
         extra = df1.loc[df1["Modalitat"].notna() & ~df1["ID"].isin(ids_totals), "ID"]
         ids_totals = np.union1d(ids_totals, extra)
     base = df1[df1["ID"].isin(ids_totals)].drop_duplicates("ID")
+
+    cols = ["ID"]
     if especie == "Isard":
-        resultat = base[["ID", "Modalitat", "Colla_ID",
-                         "Prioritat", "anys_sense_captura", "Estranger"]].copy()
-    else:
-        resultat = base[["ID", "Prioritat", "anys_sense_captura", "Estranger"]].copy()
+        cols.extend(["Modalitat", "Colla_ID"])
+    cols.extend(["Prioritat", "anys_sense_captura", "Estranger"])
+    if "Parroquia" in base.columns:
+        cols.append("Parroquia")
+
+    resultat = base[cols].copy()
 
     captures_prev = {id_: 0 for id_ in resultat["ID"]}
     resum_sorteigs = []

--- a/app_sorteig_inicial.py
+++ b/app_sorteig_inicial.py
@@ -118,7 +118,12 @@ def assignar_isards_sorteig_csv(
     df.drop(columns=['rand'], errors='ignore').to_csv(output_csv, index=False)
     return df
 
-st.set_page_config(page_title="App Sorteig Captures Isard", page_icon="🦌", layout="centered")
+st.set_page_config(
+    page_title="App Sorteig Captures Isard",
+    page_icon="🦌",
+    layout="centered",
+    menu_items={"Get Help": None, "Report a bug": None, "About": None},
+)
 
 st.title("Sorteig de Captures d'Isard")
 

--- a/pages/Dashboard.py
+++ b/pages/Dashboard.py
@@ -2,7 +2,11 @@ import streamlit as st
 import pandas as pd
 import plotly.express as px
 
-st.set_page_config(page_title="📊 Resultats sorteig", layout="wide")
+st.set_page_config(
+    page_title="📊 Resultats sorteig",
+    layout="wide",
+    menu_items={"Get Help": None, "Report a bug": None, "About": None},
+)
 st.markdown(
     """
     <style>
@@ -33,11 +37,25 @@ sense_cap = (df["anys_sense_captura"] > 0).sum()
 
 kpi1, kpi2, kpi3 = st.columns(3)
 kpi1.metric("Sol·licituds totals", f"{total:,}")
-kpi2.metric("Estrangers", f"{estrang:,}", delta=f"{estrang/total: .1%}")
-kpi3.metric(">0 anys sense captura", f"{sense_cap:,}",
-            delta=f"{sense_cap/total: .1%}")
+kpi2.metric(
+    "Estrangers",
+    f"{estrang:,}",
+    delta=f"{estrang/total: .1%}",
+    delta_color="off",
+)
+kpi3.metric(
+    ">0 anys sense captura",
+    f"{sense_cap:,}",
+    delta=f"{sense_cap/total: .1%}",
+    delta_color="off",
+)
 
 st.divider()
+
+# ── 3.1.b Resum per sorteig ─────────────────────────
+if not summary.empty:
+    st.subheader("Resum per sorteig")
+    st.dataframe(summary, use_container_width=True)
 
 # ── 3.2 Interactive filters ─────────────────────────
 with st.sidebar:


### PR DESCRIPTION
## Summary
- prevent dtype warnings by initializing `ordre` and `tipus` as object/Int64
- include `Parroquia` in sorteig results when available
- hide Streamlit default menu and neutralise KPI colours
- display a resumen table for each sorteig on the dashboard

## Testing
- `python3 -m py_compile app_sorteig.py app_sorteig_inicial.py pages/Dashboard.py`

------
https://chatgpt.com/codex/tasks/task_e_687887fabd30832086d6e94ef6579c68