### PR TITLE
Fix dashboard navigation

### DIFF
--- a/app_sorteig.py
+++ b/app_sorteig.py
@@ -424,10 +424,11 @@ def assignar_isards_sorteig_csv(df, total_captures, seed=None):
 st.markdown(
     """
     <style>
-    /* Hide the header where Streamlit shows its built-in page tabs */
+    /* Hide Streamlit's default page navigation */
     header[data-testid="stHeader"] {display: none;}
-    /* Also hide the left-sidebar page list (old navigation style) */
-    section[data-testid="stSidebarNav"] {display: none;}
+    section[data-testid="stSidebarNav"],
+    nav[data-testid="stSidebarNav"],
+    ul[data-testid="stSidebarNavItems"] {display: none;}
     </style>
     """,
     unsafe_allow_html=True

--- a/pages/Dashboard.py
+++ b/pages/Dashboard.py
@@ -185,7 +185,9 @@ def main():
         """
         <style>
         header[data-testid="stHeader"] {display: none;}
-        section[data-testid="stSidebarNav"] {display: none;}
+        section[data-testid="stSidebarNav"],
+        nav[data-testid="stSidebarNav"],
+        ul[data-testid="stSidebarNavItems"] {display: none;}
         </style>
         """,
         unsafe_allow_html=True,


### PR DESCRIPTION
## Summary
- hide Streamlit's built-in sidebar navigation to avoid duplicate menu

## Testing
- `python -m py_compile app_sorteig.py pages/Dashboard.py`

------
https://chatgpt.com/codex/tasks/task_e_687897a0aa708320aa969827f413003c