### PR TITLE
Handle missing summary columns

### DIFF
--- a/pages/Dashboard.py
+++ b/pages/Dashboard.py
@@ -65,12 +65,25 @@ def build_summaries(resultat_df: pd.DataFrame,
     else:
         summary = standardize_columns(resultat_df)
     for col in ['Assignacions_previstes', 'Assignacions_finals', 'Sol_licituds']:
-        if col in summary.columns:
-            summary[col] = pd.to_numeric(summary[col], errors='coerce').fillna(0).astype(int)
-    summary_tipus = summary.groupby(['Sorteig', 'Tipus'], as_index=False)[
-        'Assignacions_finals'].sum()
-    summary_totals = summary.groupby('Sorteig', as_index=False)[
-        ['Assignacions_previstes', 'Assignacions_finals', 'Sol_licituds']].sum()
+        if col not in summary.columns:
+            summary[col] = 0
+        summary[col] = pd.to_numeric(summary[col], errors='coerce').fillna(0).astype(int)
+    # group only when the required columns are present
+    if {'Sorteig', 'Tipus'}.issubset(summary.columns):
+        summary_tipus = summary.groupby(['Sorteig', 'Tipus'], as_index=False)[
+            'Assignacions_finals'].sum()
+    else:
+        summary_tipus = pd.DataFrame(columns=['Sorteig', 'Tipus',
+                                             'Assignacions_finals'])
+
+    if 'Sorteig' in summary.columns:
+        summary_totals = summary.groupby('Sorteig', as_index=False)[
+            ['Assignacions_previstes',
+             'Assignacions_finals', 'Sol_licituds']].sum()
+    else:
+        summary_totals = pd.DataFrame(columns=['Sorteig',
+            'Assignacions_previstes', 'Assignacions_finals', 'Sol_licituds'])
+
     return summary_totals, summary_tipus
 
 


### PR DESCRIPTION
## Summary
- prevent KeyError when summary DataFrame lacks expected columns
- fill numeric columns with zero and create empty summary DataFrames when needed

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68789d0e8cc48320955ded97f5cd7de8