### PR TITLE
Fix solicitation totals and dashboard metrics

### DIFF
--- a/app_sorteig.py
+++ b/app_sorteig.py
@@ -301,6 +301,7 @@ def processar_sorteigs(df1, df2, config, especie, seed):
         if subset["ID"].duplicated().any():
             raise ValueError(f"ID duplicats al sorteig {sorteig}")
 
+        sol_licituds_total = subset["ID"].nunique()
         part = subset.merge(df1, on="ID")
         part["Prioritat"] = part.apply(
             lambda r: (
@@ -382,7 +383,7 @@ def processar_sorteigs(df1, df2, config, especie, seed):
                 r["Quantitat"]
             )
 
-        sol_licituds = len(subset_ids)
+        sol_licituds = sol_licituds_total
         resum_rows = []
         for t in set(previs_counts) | set(tipus_counts):
             resum_rows.append(

--- a/pages/Dashboard.py
+++ b/pages/Dashboard.py
@@ -338,11 +338,10 @@ def main():
 
     st.title("📊 Resultats del sorteig")
 
+    total_apps = len(df)
     if data.empty:
         st.info("No hi ha dades després dels filtres.")
         return
-
-    total_apps = len(data)
     prev = totals_filt["Assignacions_previstes"].sum()
     # Recalculate finals from the *filtered participant* rows so percentages
     # reflect the applied filters rather than overall totals.


### PR DESCRIPTION
## Summary
- correct solicitation count for TCC in `processar_sorteigs`
- show total solicitation metric using unfiltered data in dashboard

## Testing
- `python -m py_compile app_sorteig.py pages/Dashboard.py`
- `python -m py_compile modules/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6878e15013d0832086cc40fe9cd3a4f7