### PR TITLE
Fix dtype warning when assigning capture type

### DIFF
--- a/app_sorteig.py
+++ b/app_sorteig.py
@@ -124,6 +124,8 @@ def sorteig_individual(df, tipus_quant, ordre_aleatori, vedat, rng):
         df["Parroquia"] = df["Parroquia"].apply(normalitza_parroquia)
 
     df["assigned"], df["ordre"], df["tipus"] = False, np.nan, np.nan
+    # Ensure the 'tipus' column can store strings without dtype warnings
+    df["tipus"] = df["tipus"].astype(object)
     assignats_parr = {k: 0 for k in VEDAT_PARRÒQUIES.get(vedat, {})}
 
     captures_pool = [t for t, q in tipus_quant for _ in range(q)]


### PR DESCRIPTION
## Summary
- explicitly set `tipus` column to object dtype so string values can be safely assigned

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a4d07a3d48320b63febe37e4bb3f2